### PR TITLE
ci: disable run on push

### DIFF
--- a/.github/workflows/platform-deployment.yml
+++ b/.github/workflows/platform-deployment.yml
@@ -1,7 +1,7 @@
 name: Terraform platform deployment
 on:
-  push:
-    branches: [dev, main]
+  #push:
+  #  branches: [dev, main]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Don't want this trying to deploy Terraform right now until we know where we are.  The last run failed anyway 